### PR TITLE
ChannelUtils.java

### DIFF
--- a/src/br/com/devpaulo/legendchat/channels/utils/ChannelUtils.java
+++ b/src/br/com/devpaulo/legendchat/channels/utils/ChannelUtils.java
@@ -89,8 +89,11 @@ public class ChannelUtils {
 			return;
 		}
 		if(Legendchat.getMuteManager().isServerMuted()) {
-			sender.sendMessage(Legendchat.getMessageManager().getMessage("mute_error8"));
-			return;
+		if(sender.hasPermission("legendchat.muteallspeak") || sender.hasPermission("legendchat.admin")) {
+			} else {
+				sender.sendMessage(Legendchat.getMessageManager().getMessage("mute_error8"));
+				return;
+			}
 		}
 		if(Legendchat.getIgnoreManager().hasPlayerIgnoredChannel(sender, c)) {
 			sender.sendMessage(Legendchat.getMessageManager().getMessage("error14"));


### PR DESCRIPTION
Eu não sei muito bem a ultilidade deste github mas bom eu fiz uma alteração no plugin que eu queria adicionar no meu servidor , que se você quiser colocar como oficial seria bem legal , é uma alteração até que bem util .
Isso faz com quem tenha a permissão legendchat.muteallspeak ou a legendchat.admin , consiga falar em todos os canais quando o servidor inteiro está mutado

Quando eu fui colocar o codigo eu errei , o codigo certo é este :

```
    if(Legendchat.getMuteManager().isServerMuted()) {
        if(sender.hasPermission("legendchat.muteallspeak") || sender.hasPermission("legendchat.admin")) {
        } else {
            sender.sendMessage(Legendchat.getMessageManager().getMessage("mute_error8"));
            return;
        }
    }
```
